### PR TITLE
Fix PowerShell parse errors in Windows install/uninstall scripts

### DIFF
--- a/windows_install.ps1
+++ b/windows_install.ps1
@@ -12,9 +12,10 @@ $Python      = "python"
 Write-Host "[*] Installing $ProjectName..."
 
 # Ensure admin
-if (-not ([Security.Principal.WindowsPrincipal]
-    [Security.Principal.WindowsIdentity]::GetCurrent()
-).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+$Identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+$Principal = New-Object Security.Principal.WindowsPrincipal($Identity)
+
+if (-not $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Host "[!] Please run PowerShell as Administrator"
     exit 1
 }
@@ -59,5 +60,5 @@ if ($CurrentPath -notlike "*$BinDir*") {
     )
 }
 
-Write-Host "[✓] Installation complete!"
+Write-Host "[+] Installation complete!"
 Write-Host "Restart your terminal, then run: tookie-osint"

--- a/windows_uninstall.ps1
+++ b/windows_uninstall.ps1
@@ -3,16 +3,17 @@ $InstallDir  = "C:\Program Files\$ProjectName"
 
 Write-Host "[*] Uninstalling $ProjectName..."
 
-if (-not ([Security.Principal.WindowsPrincipal]
-    [Security.Principal.WindowsIdentity]::GetCurrent()
-).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+$Identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+$Principal = New-Object Security.Principal.WindowsPrincipal($Identity)
+
+if (-not $Principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Host "[!] Run PowerShell as Administrator"
     exit 1
 }
 
 if (Test-Path $InstallDir) {
     Remove-Item -Recurse -Force $InstallDir
-    Write-Host "[✓] Removed $InstallDir"
+    Write-Host "[+] Removed $InstallDir"
 } else {
     Write-Host "[!] Not installed"
 }


### PR DESCRIPTION
## What

Fixes the parse errors reported in #101 when running `windows_install.ps1` on Windows PowerShell, and applies the same fixes to `windows_uninstall.ps1` which had identical code.

## Why it broke

1. **Multiline cast in the admin check** — splitting `([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent())` across lines makes the PowerShell parser end the statement at the newline, producing the cascade of `Missing closing ')'` errors in the issue.
2. **Non-ASCII `✓` character** — the file has no BOM, so Windows PowerShell 5.1 reads it as ANSI and the multibyte character corrupts the string, causing `The string is missing the terminator` at the end of the file.

## Changes

- Rewrote the admin check as two plain assignments using `New-Object` (works on all PowerShell versions, including pre-5.0 where `::new()` is unavailable), per @merchalex's suggestion in the issue thread.
- Replaced `[✓]` with `[+]` so both scripts are pure ASCII.

## Verification

Both scripts parse clean through the real PowerShell parser (`[System.Management.Automation.Language.Parser]::ParseFile`) in the `mcr.microsoft.com/powershell` container:

```
windows_install.ps1 parses clean
windows_uninstall.ps1 parses clean
```

Fixes #101